### PR TITLE
Add unknown STOMP status

### DIFF
--- a/lib/bluetooth_ble_stomp_client_stomp_status.dart
+++ b/lib/bluetooth_ble_stomp_client_stomp_status.dart
@@ -2,6 +2,7 @@ library bluetooth_ble_stomp_client;
 
 /// The current status of the STOMP client.
 enum BluetoothBleStompClientStompStatus {
+  unknown,
   disconnected,
   unauthenticated,
   authenticating,


### PR DESCRIPTION
An unknown STOMP status may be useful is some scenarios.

Signed-off-by: Elijah J. Passmore <elijahjpassmore@elijahjpassmore.com>