### PR TITLE
Allow user to pass in status when initialized

### DIFF
--- a/lib/bluetooth_ble_stomp_client.dart
+++ b/lib/bluetooth_ble_stomp_client.dart
@@ -25,6 +25,7 @@ class BluetoothBleStompClient {
       required this.writeCharacteristicUuid,
       this.stateCallback,
       this.logMessage,
+      this.status = BluetoothBleStompClientStompStatus.disconnected,
       this.actionDelay}) {
     _ble = FlutterReactiveBle();
     _connector = BluetoothBleStompClientDeviceConnector(
@@ -53,8 +54,7 @@ class BluetoothBleStompClient {
   late final BluetoothBleStompClientDeviceFinder _finder;
   BluetoothBleStompClientDeviceInteractor? _interactor;
 
-  BluetoothBleStompClientStompStatus status =
-      BluetoothBleStompClientStompStatus.disconnected;
+  BluetoothBleStompClientStompStatus status;
 
   /// Get the current state of the connection.
   Stream<ConnectionStateUpdate> get state => _connector.state;


### PR DESCRIPTION
There are cases when status can be presumed upon initialization.
Therefore, it makes sense to be able to pass this in as an argument.

Signed-off-by: Elijah J. Passmore <elijahjpassmore@elijahjpassmore.com>